### PR TITLE
fix: add $set function to add replaced $d UTCDate instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,14 @@ const injectDayjsClass = function (pluginPrototype, $super) {
   pluginPrototype.isUTC = function () {
     return this.$d.getTimezoneOffset() === 0
   }
+  pluginPrototype.$set = function(...args) {
+    const tzOffset = this.$d.getTimezoneOffset()
+    $super.$set.call(this, ...args)
+    if (this.$d instanceof Date) {
+      this.$d = new UTCDate(this.$d, tzOffset)
+    }
+    return this
+  }
   pluginPrototype.parse = function (cfg) {
     $super.parse.call(this, cfg)
     const { $d } = this


### PR DESCRIPTION
### What this fixes
**tl;dr** -> #6 

This PR attempts to keep `$d` pointing at a UTCDate instance since the newer versions of `dayjs` at the `$set` function, they're setting a new `Date` object instance, losing the `UTCDate` object reference.
Here's the link if you wanna take a look: https://github.com/iamkun/dayjs/blob/dev/src/index.js#L226